### PR TITLE
fix(transfer): update balance retrieval to use SpendableCoins

### DIFF
--- a/x/ibc/transfer/keeper/msg_server.go
+++ b/x/ibc/transfer/keeper/msg_server.go
@@ -89,7 +89,7 @@ func (k Keeper) Transfer(goCtx context.Context, msg *types.MsgTransfer) (*types.
 	msg.Token.Denom = pair.Denom
 
 	// if the user has enough balance of the Cosmos representation, then we don't need to Convert
-	balance := k.bankKeeper.GetBalance(ctx, sender, pair.Denom)
+	_, balance := k.bankKeeper.SpendableCoins(ctx, sender).Find(pair.Denom)
 	if balance.Amount.GTE(msg.Token.Amount) {
 
 		defer func() {

--- a/x/ibc/transfer/types/interfaces.go
+++ b/x/ibc/transfer/types/interfaces.go
@@ -39,6 +39,7 @@ type AccountKeeper interface {
 type BankKeeper interface {
 	transfertypes.BankKeeper
 	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 }
 
 // ERC20Keeper defines the expected ERC20 keeper interface for supporting


### PR DESCRIPTION
When converting from ERC20 on IBC transfer, check the sufficient balance only from the spendable balance